### PR TITLE
Removed reference to business or organization that was leftover from previous code version

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -34,7 +34,7 @@ code: |
   set_progress(56)
   eviction_not_transferred
   has_eviction_file
-  business_org_name
+  # business_org_name
   signature_date
   trial_court.division
   set_progress(70)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def find_package_data(where='.', package='', exclude=standard_exclude, exclude_d
 setup(name='docassemble.MAPetitionToSealEviction',
       version='1.0',
       description=('Petition to seal eviction'),
-      long_description='# docassemble.MAPetitionToSealEviction\r\n\r\nPetition to seal eviction\r\n\r\n## Author\r\n\r\nTaline Torossian\r\n\r\n',
+      long_description='# docassemble.PetitionToSealEviction\r\n\r\nPetition to seal eviction\r\n\r\n## Author\r\n\r\nTaline Torossian\r\n\r\n',
       long_description_content_type='text/markdown',
       author='Taline Torossian',
       author_email='Taline.Torossian@su.suffolk.edu',


### PR DESCRIPTION
There was a leftover line in the interview order block that caused an error; this PR just removes that line.