### PR TITLE
Removed the question regarding unknown occupants

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -17,7 +17,6 @@ code: |
   users.gather()
   set_progress(14)
   other_parties.gather()
-  unknown_occupants
   set_progress(28)
   trial_court
   docket_number

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -148,15 +148,6 @@ fields:
   - "Anyone else?": anyone_else
     datatype: yesnoradio
 ---
-id: Are Unknown Occupants listed as defendants on your Eviction Complaint
-question: |
-  Are “Unknown Occupants” listed as defendants on your Eviction Complaint?
-subquestion: |
-  Answer Yes if they were listed on the Eviction Complaint. They could be listed as defendants or there might be a checkbox.
-fields:
-  - "Unknown occupants": unknown_occupants
-    datatype: yesnoradio
----
 id: Have you contacted the other parties about removing the eviction from the public record
 question: |
   Have you contacted the other parties about removing the eviction from the public record?


### PR DESCRIPTION
There was a question about unknown occupants that won't be needed in this interview. This change removed the code block. 