### PR TITLE
Integrate notice of appearance

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -201,8 +201,6 @@ code: |
   set_progress(75)
   nav.set_section("landlord_info")
   other_parties.gather()
-  other_parties[0].name.first
-  other_parties.there_is_another
   
   nav.set_section("attorney_info")
   if al_person_answering == "attorney":
@@ -216,6 +214,11 @@ code: |
   notice_type
 
   signature_date
+
+  # Trigger definitions for notice of appearance
+  petitioners
+  respondents
+
   interview_order_petition_to_seal_eviction = True
 ---
 ###################### Main order ######################

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -4,7 +4,7 @@ include:
   - docassemble.MassAccess:massaccess.yml
   - docassemble.MATCTheme:matc_theme.yml
   - docassemble.ALToolbox:collapse_template.yml
-  - docassemble.docassemble.MANoticeOfAppearanceForm:notice_of_appearance_form.yml
+  - docassemble.MANoticeOfAppearanceForm:notice_of_appearance_form.yml
 ---
 metadata:
   title: >-
@@ -284,7 +284,7 @@ fields:
       - Tenant asking to seal my eviction case: user
       - Attorney for the tenant: attorney
   - Is this your **first** appearance on behalf of this tenant?: attorney_first_appearance
-    datatype: yesno
+    datatype: yesnoradio
     show if:
       variable: al_person_answering
       is: "attorney"
@@ -292,6 +292,7 @@ fields:
       Okay. Because this is your first appearance in this eviction case, 
       we will also make a **notice of appearance** form for you. The notice
       of appearance will be filed along with the Petition to Seal Eviction.
+    show if: attorney_first_appearance
 ---
 id: Attorney Message
 continue button field: attorney_message

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -4,6 +4,7 @@ include:
   - docassemble.MassAccess:massaccess.yml
   - docassemble.MATCTheme:matc_theme.yml
   - docassemble.ALToolbox:collapse_template.yml
+  - docassemble.docassemble.MANoticeOfAppearanceForm:notice_of_appearance_form.yml
 ---
 metadata:
   title: >-
@@ -282,6 +283,15 @@ fields:
     choices:
       - Tenant asking to seal my eviction case: user
       - Attorney for the tenant: attorney
+  - Is this your **first** appearance on behalf of this tenant?: attorney_first_appearance
+    datatype: yesno
+    show if:
+      variable: al_person_answering
+      is: "attorney"
+  - note: |
+      Okay. Because this is your first appearance in this eviction case, 
+      we will also make a **notice of appearance** form for you. The notice
+      of appearance will be filed along with the Petition to Seal Eviction.
 ---
 id: Attorney Message
 continue button field: attorney_message
@@ -607,7 +617,10 @@ subquestion: |
 continue button field: petition_to_seal_eviction_preview_question    
 ---
 code: |
-  signature_fields = ['users[0].signature']
+  if al_person_answering == "attorney":
+    signature_fields = ['attorneys[0].signature', 'users[0].signature']
+  else:
+    signature_fields = ['users[0].signature']
 ---
 code: |
   addresses_to_search = [users[0].tenancy_address]
@@ -929,8 +942,26 @@ objects:
 ---
 # Bundles group the ALDocuments into separate downloads, such as for court and for the user
 objects:
-  - al_user_bundle: ALDocumentBundle.using(elements=[petition_to_seal_eviction_Post_interview_instructions, petition_to_seal_eviction_attachment], filename="petition_to_seal_eviction", title="All forms to download for your records", enabled=True)
-  - al_court_bundle: ALDocumentBundle.using(elements=[petition_to_seal_eviction_attachment],  filename="petition_to_seal_eviction", title="All forms to deliver to court", enabled=True)
+  - al_user_bundle: ALDocumentBundle.using(elements=[
+              petition_to_seal_eviction_Post_interview_instructions,
+              petition_to_seal_eviction_attachment,
+              notice_of_appearance_form_attachment,
+            ],
+            filename="petition_to_seal_eviction",
+            title="All forms to download for your records", 
+            enabled=True
+          )
+  - al_court_bundle: ALDocumentBundle.using(elements=[
+            petition_to_seal_eviction_attachment,
+            notice_of_appearance_form_attachment,
+          ],
+          filename="petition_to_seal_eviction",
+          title="All forms to deliver to court",
+          enabled=True
+          )
+---
+code: |
+  notice_of_appearance_form_attachment.enabled = al_person_answering == "attorney" and attorney_first_appearance
 ---
 # Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the same template is 
 # used for "preview" and "final" keys, and logic in the template checks the value of 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MAPetitionToSealEviction',
       license='The MIT License',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.AssemblyLine>=3.2.0'],
+      install_requires=['docassemble.AssemblyLine>=3.2.0','docassemble.MANoticeOfAppearanceForm @ https://github.com/docassemble/docassemble-MANoticeOfAppearanceForm/archive/refs/trees/main.zip'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MAPetitionToSealEviction/', package='docassemble.MAPetitionToSealEviction'),
      )


### PR DESCRIPTION
Per trial court request - if someone hasn't already filed an appearance in the case, they want an appearance for the attorney to be filed with the petition to seal eviction.

1. Updated and edited the Notice of Appearance interview that Landon made, so it can be easily included in another interview
2. Linked it to this interview
3. Triggered it so it appears when an attorney is filing the petition, and its the first appearance they are filing in the case.