### PR TITLE
restore priority to the cached login information, if it exists

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -341,6 +341,33 @@ code: |
       log(word("You are now connected to your e-filing account"), "primary")
   tyler_login = True
 ---
+need:
+  - proxy_conn
+  - da_store
+code: |
+    tyler_header_name = f"TYLER-TOKEN-{jurisdiction_id.upper()}"
+    tyler_id_name = f"TYLER-ID-{jurisdiction_id}"
+    try:
+      if da_store.defined("EFSP-" + tyler_header_name):
+        proxy_conn.proxy_client.headers[tyler_header_name] = da_store.get("EFSP-" + tyler_header_name)
+        proxy_conn.proxy_client.headers[tyler_id_name] = da_store.get("EFSP-" + tyler_id_name)
+        tyler_user = proxy_conn.get_user()
+        if tyler_user.is_ok():
+          my_username = tyler_user.data.get('email')
+          if continue_stored_login:
+            log(word("You are now connected to your e-filing account") + f" ({my_username})", "primary")
+            logged_in_user_is_admin, logged_in_user_is_global_admin = get_tyler_roles(proxy_conn, None, tyler_user)
+            tyler_login = True
+          else:
+            da_store.set("EFSP-" + tyler_header_name, '')
+            da_store.set(tyler_user_id_key, '')
+    except NameError as err:
+      # Re-raise only name errors, so DA can work correctly
+      raise err
+    except Exception as ex:
+      log_error_and_notify(f"Error when trying to get da_store Tyler token: {ex}")
+
+---
 if: can_connect_to_proxy
 id: unauth-register-done
 question: |


### PR DESCRIPTION
Fix #100

Help advocates who might be filing many petitions in a row