### PR TITLE
Use the case type from the existing case when we use a Tyler account and can detect it

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -333,16 +333,41 @@ subquestion: |
 
   ${ collapse_template(eviction_reason_template) }
 
-  The landlord told the court in the summons and complaint that:
+  % if can_check_efile and case_search.found_case and predicted_eviction_reason:
+  <div class="border rounded p-3 alert-info text-dark" style="position: relative; overflow: visible; word-wrap: break-word;">
+    <p><i class="fa-solid fa-circle-info"></i>
+    We used the information we found in your court records to automatically
+    choose an answer for this question.
+    </p>
+    <p>
+    If the checked answer is not right, you can un-check our answer
+    and check the right answer. You might need to explain to the clerk or the judge
+    that there is a mistake in your court file at the hearing.  
+    </p>
+  </div>
+  % endif
 fields:
-  - "Nonpayment of rent: I owed money for rent ": eviction_reason_nonpayment
-    datatype: yesnowide
-  - "Fault: I broke the lease other than owing rent. For example: a noise complaint or damage to the apartment, or repeatedly paying the rent late.": eviction_reason_fault
-    datatype: yesnowide
-  - "No fault: They did not want to rent to me any longer, but not because of something I did": eviction_reason_nofault
-    datatype: yesnowide
-  - "139 § 19: I broke the law and they filed an emergency eviction under G.L. c. 139, § 19. For example, they claim I had drugs, had an illegal weapon, acted violently, or violated another criminal law.": eviction_reason_139
-    datatype: yesnowide
+  - The landlord told the court in the summons and complaint that: eviction_reason
+    label above field: True
+    datatype: radio
+    choices:
+      - "Non-payment of rent: I owed money for rent": eviction_reason_nonpayment
+      - "Fault: I broke the lease other than owing rent. For example: a noise complaint or damage to the apartment, or repeatedly paying the rent late.": eviction_reason_fault
+      - "No fault: They did not want to rent to me any longer, but not because of something I did": eviction_reason_nofault
+      - "139 § 19: I broke the law and they filed an emergency eviction under G.L. c. 139, § 19. For example, they claim I had drugs, had an illegal weapon, acted violently, or violated another criminal law.": eviction_reason_139
+    default: ${ showifdef("predicted_eviction_reason") }
+validation code: |
+  # TODO: we can remove this validation code if we update template to new format
+  eviction_reason_nonpayment = eviction_reason_fault = eviction_reason_nofault = eviction_reason_139 = False
+
+  if eviction_reason == "eviction_reason_nonpayment":
+    eviction_reason_nonpayment = True
+  elif eviction_reason == "eviction_reason_fault":
+    eviction_reason_fault = True
+  elif eviction_reason == "eviction_reason_nofault":
+    eviction_reason_nofault = True
+  elif eviction_reason == "eviction_reason_139":
+    eviction_reason_139 = True
 ---
 template: eviction_reason_template
 subject: |
@@ -351,14 +376,12 @@ content: |
   Look at the paperwork that you got from your landlord and from the court. Look for the key words:
 
   * "Nonpayment of rent"
-  * "Breach of lease"
-  * "No fault" or "without the fault of the tenant"
-  * "139 § 19" or "nuisance" 
-
-  It may list one reason, or more than one reason.
+  * "Cause" or "Breach of lease"
+  * "No cause", "No fault" or "without the fault of the tenant"
+  * "139 § 19" or "nuisance"
 
   Even if you were evicted for a "fault" reason, your landlord may have also listed a "nonpayment" reason.
-  Make sure to also check the box for "fault" if the landlord said in the court paperwork that you broke another part of the lease.
+  Make sure to check the box for "fault" if the landlord said in the court paperwork that you broke another part of the lease.
 ---
 id: Off Ramp
 decoration: hand

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -18,19 +18,21 @@ include:
 code: |
   nav.set_section('review_efile_info')
   if can_check_efile:
-    users[0].is_form_filler
-    efile_case_category
-    efile_case_type
-    cross_references.gather()
-    show_any_disclaimers
-    # petition_to_seal_eviction_attachment.completed # Trigger the e-filing specific variables. I don't really like this being hidden like it is now though!
-    al_court_bundle.filing_parties
-    for item in al_court_bundle.enabled_documents():
-      item.filing_parties
-    al_court_bundle.completed
-    review_fees
-    ready_to_efile
-
+    if petition_is_efileable:
+      users[0].is_form_filler
+      efile_case_category
+      efile_case_type
+      cross_references.gather()
+      show_any_disclaimers
+      # petition_to_seal_eviction_attachment.completed # Trigger the e-filing specific variables. I don't really like this being hidden like it is now though!
+      al_court_bundle.filing_parties
+      for item in al_court_bundle.enabled_documents():
+        item.filing_parties    
+      al_court_bundle.completed
+      review_fees
+      ready_to_efile
+    else:
+      warn_sorry_not_efileable
   interview_order_efiling = True
 ---
 code: |
@@ -39,7 +41,13 @@ code: |
 code: |
   # TODO: add any restrictions here
   # e.g., currently we don't handle 139 section 19 cases
-  petition_is_efileable = True
+  if can_check_efile and case_search.case_was_found:
+    # Check the case type for a valid one
+    if predicted_eviction_reason in ("eviction_reason_nofault", "eviction_reason_fault", "eviction_reason_nonpayment"):
+      petition_is_efileable = True
+    else:
+      petition_is_efileable = False
+      # Currently, there is no Petition to Seal Eviction code for any other case types
 ---
 code: |
   is_initial_filing = False
@@ -58,6 +66,7 @@ code: |
   jurisdiction_id = 'massachusetts'
 ---
 code: |
+  # TODO: rename?
   proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction=jurisdiction_id)
 ---
 code: |
@@ -367,4 +376,78 @@ code: |
 ---
 generic object: ALDocumentBundle
 code: |
-  x.filing_parties = ['users[0]']    
+  x.filing_parties = ['users[0]']
+---
+id: display case
+generic object: EFCaseSearch
+continue button field: x.display_case
+question: |
+  We found your case
+subquestion: |
+  % if x.cms_connection_issue:
+  The court's case management system is currently offline. The case information might be out of date.
+  % endif
+  
+  % if x.found_case:
+  #### ${ x.found_case.title} ${ '(' + x.found_case.date + ')' if x.found_case.date.year > 1000 else '' }
+  * ${ str(x.docket_lookup_choice) }: ${ x.found_case.docket_number }
+  * Court ID: ${ x.found_case.court_id }
+  * Case Category: ${ x.found_case.case_category_name }
+  * Case Type: ${ x.found_case.case_type_name }  
+  % endif
+
+  ${ collapse_template(x.not_actually_case) }
+---
+generic object: EFCaseSearch
+code: |
+  # Note the proxy connection needs to be called proxy_conn for this to work
+  x.found_case.case_type_name = proxy_conn.get_case_type(court_id, x.found_case.case_type).data.get('name', x.found_case.case_type)
+  x.found_case.case_category_name = x.case_category_map.get(x.found_case.category, {}).get('name', x.found_case.category)
+---
+generic object: EFCaseSearch
+code: |
+  # found case instance name might be weird if it's a name search
+  x.found_cases[i].case_type_name = proxy_conn.get_case_type(court_id, x.found_cases[i].case_type).data.get('name', x.found_cases[i].case_type)
+  x.found_cases[i].case_category_name = x.case_category_map.get(x.found_cases[i].category, {}).get('name', x.found_cases[i].category)
+---
+generic object: EFCaseSearch
+template: x.not_actually_case
+subject: |
+  What if this is not my case?
+content: |
+  If we found the wrong case, you can press the "${ all_variables(special="titles").get("back button label", "back") }" button to go back and find a different case
+---
+code: |
+  if can_check_efile and case_search.found_case:
+    if 'no cause' in case_search.found_case.case_type_name.lower():
+      predicted_eviction_reason = "eviction_reason_nofault"
+    elif 'cause' in case_search.found_case.case_type_name.lower():
+      predicted_eviction_reason = "eviction_reason_fault"
+    elif 'non-payment' in case_search.found_case.case_type_name.lower():
+      predicted_eviction_reason = "eviction_reason_nonpayment"
+    elif 'foreclosure' in case_search.found_case.case_type_name.lower():
+      predicted_eviction_reason = "eviction_reason_foreclosure"
+    elif "civil" in case_search.found_case.case_type_name.lower() or "restraining order" in case_search.found_case.case_type_name.lower():
+      predicted_eviction_reason = "eviction_reason_139"
+    else:
+      predicted_eviction_reason = None
+  else:
+    predicted_eviction_reason = None
+---
+id: warn_sorry_not_efileable
+continue button field: warn_sorry_not_efileable
+decoration: info-circle
+question: |
+  You cannot e-file this document
+subquestion: |
+  This document cannot currently be e-filed. 
+  
+  Only cases that are coded as "Summary Process" can be e-filed right now.
+
+  % if predicted_eviction_reason == "eviction_reason_139":
+  This case looks like it is a 139 § 19 case. You can still file this document in-person at the court.
+  % else:
+  It does not look like this is an eviction case. You can still bring this document in-person
+  to the court and talk to a clerk about your sealing options.
+  % endif
+  

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MAPetitionToSealEviction',
       license='The MIT License',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.AssemblyLine>=3.2.0'],
+      install_requires=['docassemble.AssemblyLine>=3.2.0', 'docassemble.EFSPIntegration>=1.5.2'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MAPetitionToSealEviction/', package='docassemble.MAPetitionToSealEviction'),
      )


### PR DESCRIPTION
Fix #91 - pull case type, fix #95; fix #66

Makes a new variable, `predicted_eviction_reason` which can be one of:

- eviction_reason_nofault
- eviction_reason_fault
- eviction_reason_nonpayment
- eviction_reason_foreclosure
- eviction_reason_139

This is defined by looking for keywords like "non-payment" and "cause" or "no-cause" in the case type.

Also defines a new variable, `petition_is_efileable` that checks to make sure the predicted_eviction_reason is one of fault, nofault, or nonpayment as those are the only case types we can currently file into.