### PR TITLE
Simplify efiling experience

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -246,7 +246,7 @@ code: |
   petition_to_seal_eviction_intro
   interview_order_petition_to_seal_eviction
 
-  interview_order_efiling
+  
 
   signature_date
   # Store anonymous data for analytics / statistics
@@ -258,10 +258,14 @@ code: |
       },
   )
   set_progress(99)
+  
   petition_to_seal_eviction_preview_question
-  users[0].states_above_true
   basic_questions_signature_flow
+  if can_check_efile and petition_is_efileable and case_search.found_case:    
+    interview_order_efiling    
+    efile_once
   petition_to_seal_eviction_download
+  
 ---
 id: Petition_to_Seal_Eviction
 continue button field: petition_to_seal_eviction_intro
@@ -1047,13 +1051,17 @@ event: petition_to_seal_eviction_download
 question: |
   Your petition information has been filled out
 subquestion: |
-  Thank you ${users}. Your form is ready to download and deliver.
+  % if can_check_efile and petition_is_efileable and showifdef('efile'):
+  Thank you ${users}. Your form has been delivered. You can download a copy
+  of your form below. You will get updates about your case by email.
+  % else:
+  Thank you ${users}. Your form is ready to download and deliver to the court.
 
-  Make sure you are able to print or eFile the form once you have reviewed. 
+  Make sure you are able to print or eFile the form once you have reviewed.
 
   If you are not ready to file, make an account to save your completed form.
   
-  View, download and send your form below. Click the "Edit answers" button to fix any mistakes.
+  View and download your form below. Click the "Edit answers" button to fix any mistakes.
 
   % if defined("continue_inapplicable"):
   <div class="alert alert-warning" role="alert">
@@ -1076,16 +1084,16 @@ subquestion: |
 
   % endif
 
+  % endif # can_check_efile and petition_is_efileable and showifdef('efile')
   
   <h2 class="h4">Download for your records</h2>
   ${ al_user_bundle.download_list_html() }
   
-
   ${ al_user_bundle.send_button_html(show_editable_checkbox=True) }
 
-  
 
 progress: 100
+prevent going back: True
 ---
 # ALDocument objects specify the metadata for each template
 objects:

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -1091,6 +1091,7 @@ subquestion: |
   
   ${ al_user_bundle.send_button_html(show_editable_checkbox=True) }
 
+  ${ action_button_html(url_of("new_session"), label="Start a new petition", icon="square-plus", size="md", color="secondary") }
 
 progress: 100
 prevent going back: True

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -749,7 +749,7 @@ fields:
     choices: all_matches
     none of the above: |
       A court not listed here
-    disable others: True
+    # disable others: True
     object labeler: court_short_description
     show if: 
       code: |
@@ -758,6 +758,9 @@ fields:
     datatype: object
     object labeler: court_short_label
     choices: all_courts.filter_courts(allowed_courts)
+    show if:
+      variable: trial_court
+      is: null
 ---
 id: name of landlord
 question: |

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -721,6 +721,17 @@ code: |
 code: |
   addresses_to_search = [users[0].tenancy_address]
 ---
+id: choose a court (no courts matching provided address were found)
+question: |
+  What court was your case decided in?
+subquestion: |
+  Look at your court paperwork. Match the name listed there.
+fields:
+  - no label: trial_court
+    datatype: object
+    object labeler: court_short_label
+    choices: all_courts.filter_courts(allowed_courts)   
+---
 if: |
   len(all_matches) and all_courts.filter_courts(allowed_courts) 
 id: choose a court (courts matching provided address were found)

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -88,9 +88,6 @@ code: |
 
   al_court_bundle.filing_type_filters = ['Petition to Seal Eviction Record', 'Seal Eviction']
   al_court_bundle.filing_type_default = '101805'
-# ---
-# code: |
-#   notice_of_appearance_form_attachment.filing_component = 'attachment'
 ---
 code: |
   users[i].party_type_filters = ['Defendant/Appellant', 'Defendant/Petitioner']

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -255,9 +255,9 @@ code: |
 ---
 id: eFile Login
 question: |
-  Connect to your eFile MA account
+  Connect to your eFileMA account
 subquestion: |
-  You need to use an eFile MA account to e-file this document. If you don't have an account yet, we can help you make one.
+  You need to use an eFileMA account to e-file this document. If you don't have an account yet, we can help you make one.
 
   ${ collapse_template(what_is_efile_ma_template) }
 fields:
@@ -282,9 +282,9 @@ fields:
 ---
 template: what_is_efile_ma_template
 subject: |
-  What is eFile MA?
+  What is eFileMA?
 content: |
-  eFile MA is the Massachusetts Trial Court's official system for electronically
+  eFileMA is the Massachusetts Trial Court's official system for electronically
   filing court documents. It is also called File and Serve.
 
   This website can help you securely connect to eFileMA using your existing eFileMA

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -197,6 +197,9 @@ generic object: ALDocument
 id: extra e-filing questions
 question: |
   Send a copy of this filing to someone else?
+subquestion: |
+  If you answer "yes", a copy of all notices will be delivered to the email below when the
+  document is electronically filed.
 fields:
   - Add a courtesy email: x.has_courtesy_copies
     datatype: yesnoradio

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -37,6 +37,12 @@ code: |
       warn_sorry_not_efileable
   interview_order_efiling = True
 ---
+id: efile
+code: |
+  # Q: I put this in its own block to prevent possible idempotency issues. Not sure if necessary
+  efile
+  efile_once = True
+---
 code: |
   form_uses_efiling = True
 ---
@@ -491,4 +497,24 @@ subquestion: |
   to the court and talk to a clerk about your sealing options.
   % endif
   % endif
+---
+id: submitted form
+question: |
+  % if efile_resp.response_code == 200:
+  Your forms are on their way to ${ trial_court }
+  % else:
+  Something went wrong delivering your form
+  % endif
+subquestion: |
+  % if efile_resp.response_code == 200:
+  You should receive a confirmation email within 10-15 minutes, and
+  you should receive an update from the ${ trial_court } clerk on your filing 
+  within 48 hours.
   
+  We recommend you continue below to download the form for your own records.
+  Click **Next** to get a copy of your forms and instructions.
+  % endif
+
+  ${ collapse_template(debug_details) }
+
+continue button field: show_efile_resp

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -27,7 +27,9 @@ code: |
       # petition_to_seal_eviction_attachment.completed # Trigger the e-filing specific variables. I don't really like this being hidden like it is now though!
       al_court_bundle.filing_parties
       for item in al_court_bundle.enabled_documents():
-        item.filing_parties    
+        item.filing_component
+        item.filing_type
+        item.filing_parties
       al_court_bundle.completed
       review_fees
       ready_to_efile
@@ -72,33 +74,23 @@ code: |
   proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction=jurisdiction_id)
 ---
 code: |
-  # Can be filed in District Court, BMC, and Housing Court.
-  # I think we don't need this, since filing type isn't limited to either case category
-  # efile_case_category_filters = ['Summary Process', 'Civil']
-  # # This value will be selected at a lower priority, only if there's an ambiguous match.
-  # efile_case_category_default = '8530' # 8730 on staging
-  # efile_case_category_exclude = None
-
-  # # Case type is not needed in this interview: there are multiple allowed case types within the broader summary process
-  # # Not sure this is right way to specify this yet. TODO: investigate
-  # efile_case_type_filters = None # ['SP', 'Temporary Restraining Order', 'Civil']
-
-  # efile_case_type_default = ''
-  # efile_case_type_exclude = None
----
-code: |
   if can_check_efile and case_search.case_was_found:
     efile_case_category = case_search.found_case.category
     efile_case_type = case_search.found_case.case_type
 ---
 code: |
   # https://efile-test.suffolklitlab.org/jurisdictions/massachusetts/codes/courts/537/filing_types/101805
+  petition_to_seal_eviction_attachment.filing_type_filters = ['Petition to Seal Eviction Record', 'Seal Eviction']
+  petition_to_seal_eviction_attachment.filing_type_default = '101805'
+
+  notice_of_appearance_form_attachment.filing_type_filters = ['Attorney Appearance']
+  notice_of_appearance_form_attachment.filing_type_default = '9124'
 
   al_court_bundle.filing_type_filters = ['Petition to Seal Eviction Record', 'Seal Eviction']
   al_court_bundle.filing_type_default = '101805'
-  
-  petition_to_seal_eviction_attachment.filing_type_filters = ['Petition to Seal Eviction Record', 'Seal Eviction']
-  petition_to_seal_eviction_attachment.filing_type_default = '101805'
+# ---
+# code: |
+#   notice_of_appearance_form_attachment.filing_component = 'attachment'
 ---
 code: |
   users[i].party_type_filters = ['Defendant/Appellant', 'Defendant/Petitioner']
@@ -114,19 +106,30 @@ id: user-wants-efile
 question: |
   Do you want to e-file this document directly with the court?
 subquestion: |
-  You are able to electronically-file (e-file) this document with the court your eviction was filed in!
-  
-  This means you don't have to print out the document. The court
-  will communicate with you through your email or phone.
+  E-filing is completely free and is the fastest way to file this document.
 
-  You will have to use your eFileMA account to e-file this document. 
-  If you don't wish to use your account or don't wish to make an account,
-  you can choose not to efile.
-  
-  If you don't have a eFileMA account, you can make one in the next screens.
+  You need a free account with eFileMA to e-file this document. We can help you make the account on
+  the next screens if you do not already have one.
+
+  ${ collapse_template(to_make_an_account_you_need_template) }
+
+  ${ collapse_template(what_is_efile_ma_template) }
+
+  If you do not want to e-file this document, you can print it at the end of this interview and deliver it to the court
+  in-person or by mail.
 fields:
   - Do you want to e-file?: user_wants_efile
     datatype: yesnoradio
+---
+template: to_make_an_account_you_need_template
+subject: |
+  What do I need to make an account?
+content: |
+  To make an account, you will need:
+  
+  * an email address you can access,
+  * a phone number, and
+  * an address where you can get mail.  
 ---
 comment: |
   TODO: this might need to be modified to prevent loading the old address on the user? Presumably they moved by now
@@ -270,10 +273,14 @@ fields:
     show if:
       variable: user_login_or_make_new
       is: existing_account
+    default: |
+      ${ showifdef("person_to_reg.email") or (user_info().email if user_logged_in() else '') }
   - Password: my_password
     datatype: ALVisiblePassword
     js show if: |
       val("user_login_or_make_new") == "existing_account" && !val("user_forgot_password")
+    default: |
+      ${ showifdef("new_password") }
   - I forgot my password: user_forgot_password
     datatype: yesno
     show if:


### PR DESCRIPTION
Some fixes to streamline e-filing experience. Touches a few sections of the code, so integrated a few additional fixes.

* Major change is that the e-filing experience is now in-line, instead of an extra button that the user clicks on the download screen. The user still sees a preview of their form before the download screen.
* Adjusted the copy on the download screen to reflect that the user already delivered it (if they chose e-file).
* Added code to allow e-filing the Notice of Appearance

Some usability fixes:

* Improved copy on e-filing intro screen
* Default login screen to details just used to register for an account
* Hide the manual court selection drop-down if the user picks one of the courts we found to match their address. Obviates #73 
* Added a "File a new petition" button to simplify use by advocates

Fix #104  fix #73 Fix #107 Fix #45 