### PR TITLE
Add Brockton session warning to three screens

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -933,13 +933,33 @@ fields:
     datatype: object
     object labeler: court_short_label
     choices: all_courts.filter_courts(allowed_courts)
+    css class: trial_court_other_select
     show if:
       variable: trial_court
       is: null
   - note: |
       ${ brockton_session_warning }
-    js show if:
-      val("trial_court") === "all_courts[16]"
+script: |
+  <script>
+    // Shows and hides the `brockton_session_warning` template when "Brockton District Court" is selected.
+    const select = $('.trial_court_other_select-container select');
+    const warning = $('.brockton_session_warning');
+  
+    if ( select.css('display') === 'block' ) {
+      show_hide_warning();
+    }
+  
+    $(select).on('change', show_hide_warning);
+  
+    function show_hide_warning() {
+      let label = select.children('[value="' + select.val() + '"]').text();
+      if ( label === 'Brockton District Court') {
+        warning.show();
+      } else {
+        warning.hide();
+      }
+    }
+  </script>
 ---
 # code: |
 #   # Because we disabled name lookup

--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -936,6 +936,10 @@ fields:
     show if:
       variable: trial_court
       is: null
+  - note: |
+      ${ brockton_session_warning }
+    js show if:
+      val("trial_court") === "all_courts[16]"
 ---
 # code: |
 #   # Because we disabled name lookup
@@ -1075,6 +1079,10 @@ question: |
   What is the docket number (also called the "case number") for your eviction case?
 subquestion: |
   ${ collapse_template(find_my_docket_number_template) }
+
+  % if trial_court.name == "Brockton District Court":
+  ${ brockton_session_warning }
+  % endif
 fields:
   - Docket number: docket_number
     under text: |

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -76,7 +76,7 @@ code: |
 ---
 template: brockton_session_warning
 content: |
-  <div class="alert alert-warning" role="alert" markdown="1" style="overflow: hidden;">
+  <div class="alert alert-warning brockton_session_warning" role="alert" markdown="1" style="overflow: hidden;">
     **Attention Housing Court filers**
   
     Cases filed on or before 2017 in the Southeast Division Brockton Session are now handled by the Metro South Division. Petitions associated with these cases cannot be filed electronically and must be filed in person in the Metro South Division.

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -645,10 +645,7 @@ subquestion: |
   ${ collapse_template(what_is_efile_ma_template) }
 
   <div class="alert alert-warning" role="alert">
-    <strong>Warning</strong>: you need to use an individual filer account, not a "firm" account
-    to file this petition.
-    <br/>
-    Choose "new account" if you have an existing account but it is managed by your firm.
+    <strong>Warning</strong>: you need to use an individual filer account, not a "firm" account to file this petition. Choose "new account" if you have an existing account but it is managed by your firm.
   </div>
 fields:
   - I want to: user_login_or_make_new

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -74,6 +74,14 @@ question: |
 code: |
   efile_calculation_task = background_action("efile_calculation_background_task")
 ---
+template: brockton_session_warning
+content: |
+  <div class="alert alert-warning" role="alert" markdown="1" style="overflow: hidden;">
+    **Attention Housing Court filers**
+  
+    Cases filed on or before 2017 in the Southeast Division Brockton Session are now handled by the Metro South Division. Petitions associated with these cases cannot be filed electronically and must be filed in person in the Metro South Division.
+  </div>
+---
 event: efile_calculation_background_task
 code: |
   # All the time-consuming stuff that doesn't require user interaction  
@@ -386,6 +394,10 @@ subquestion: |
 
   If you do not want to e-file this document, you can print it at the end of this interview and deliver it to the court
   in-person or by mail.
+
+  % if trial_court.name == "Brockton District Court":
+  ${ brockton_session_warning }
+  % endif
 fields:
   - Do you want to e-file?: user_wants_efile
     datatype: yesnoradio
@@ -929,6 +941,10 @@ subquestion: |
   make sure that it is correct.
 
   ${ collapse_template(find_my_docket_number_template) }
+
+  % if trial_court.name == "Brockton District Court":
+  ${ brockton_session_warning }
+  % endif
 fields:
   - ${ str(x.docket_lookup_choice) }: x.docket_number_from_user
     under text: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description_file = README.md
+long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MAPetitionToSealEviction',
       license='The MIT License',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.AssemblyLine @ git+https://github.com/SuffolkLITLab/docassemble-AssemblyLine.git@main', 'docassemble.EFSPIntegration @ git+https://github.com/SuffolkLITLab/docassemble-EFSPIntegration.git@main'],
+      install_requires=['docassemble.AssemblyLine>=3.2.0', 'docassemble.EFSPIntegration>=1.5.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MAPetitionToSealEviction/', package='docassemble.MAPetitionToSealEviction'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MAPetitionToSealEviction',
       license='The MIT License',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.AssemblyLine>=3.2.0', 'docassemble.EFSPIntegration>=1.5.1'],
+      install_requires=['docassemble.AssemblyLine @ git+https://github.com/SuffolkLITLab/docassemble-AssemblyLine.git@main', 'docassemble.EFSPIntegration @ git+https://github.com/SuffolkLITLab/docassemble-EFSPIntegration.git@main'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MAPetitionToSealEviction/', package='docassemble.MAPetitionToSealEviction'),
      )


### PR DESCRIPTION
Add the warning/disclaimer requested by the MA Trial Court to four screens (`id: docket id` doesn't seem to be used, but I added it just in case).

Closes #228

**Note: this is based on the main branch, which [currently has e-filing disabled](https://github.com/SuffolkLITLab/docassemble-MAPetitionToSealEviction/commit/e4bbf221595045bebdda8eacf5a136697c864242).**