### PR TITLE
Correct which brockton court should trigger warning

### DIFF
--- a/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/petition_to_seal_eviction.yml
@@ -941,7 +941,7 @@ fields:
       ${ brockton_session_warning }
 script: |
   <script>
-    // Shows and hides the `brockton_session_warning` template when "Brockton District Court" is selected.
+    // Shows and hides the `brockton_session_warning` template when the Brockton Session is selected.
     const select = $('.trial_court_other_select-container select');
     const warning = $('.brockton_session_warning');
   
@@ -953,7 +953,7 @@ script: |
   
     function show_hide_warning() {
       let label = select.children('[value="' + select.val() + '"]').text();
-      if ( label === 'Brockton District Court') {
+      if ( label === 'Metro South Housing Court - Brockton Session') {
         warning.show();
       } else {
         warning.hide();
@@ -1100,7 +1100,7 @@ question: |
 subquestion: |
   ${ collapse_template(find_my_docket_number_template) }
 
-  % if trial_court.name == "Brockton District Court":
+  % if trial_court.name == "Metro South Housing Court - Brockton Session":
   ${ brockton_session_warning }
   % endif
 fields:

--- a/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
+++ b/docassemble/MAPetitionToSealEviction/data/questions/support_efiling.yml
@@ -395,7 +395,7 @@ subquestion: |
   If you do not want to e-file this document, you can print it at the end of this interview and deliver it to the court
   in-person or by mail.
 
-  % if trial_court.name == "Brockton District Court":
+  % if trial_court.name == "Metro South Housing Court - Brockton Session":
   ${ brockton_session_warning }
   % endif
 fields:
@@ -939,7 +939,7 @@ subquestion: |
 
   ${ collapse_template(find_my_docket_number_template) }
 
-  % if trial_court.name == "Brockton District Court":
+  % if trial_court.name == "Metro South Housing Court - Brockton Session":
   ${ brockton_session_warning }
   % endif
 fields:


### PR DESCRIPTION
Discussed with Linette today, and realized that we should be showing warning on the 'Metro South Housing Court - Brockton Session', not the Brockton District Court (different court system).

We were previously been confused by the warning language about the "Southeast Division Brockton Session" court that no longer exists (and must not exist in our MACourts selection).