### PR TITLE
Fix missing package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,10 @@ dependencies = [
 where = [
     ".",
 ]
+[tool.setuptools.package-data]
+"*" = [
+    "*.yml",
+    "*.yaml",
+    "*.docx",
+    "*.md",
+]


### PR DESCRIPTION
Removing `setup.py` caused yml and docx files to not be included in the package, throwing 404s when loading interviews. Added package-data config to pyproject.toml