### PR TITLE
Fix build config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include README.md
+graft docassemble/MAPetitionToSealEviction/data
+recursive-exclude * *.egg-info
+recursive-exclude .git *
+recursive-exclude * __pycache__
+recursive-exclude * *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools==80.9.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-long_description = file: README.md


### PR DESCRIPTION
Pin setuptools to 80.9.0 to fix pip resolution failure during dainstall and adds data directory to MANIFEST.in so yml and docx files are included in the package
