### PR TITLE
Install MANoticeOfAppearanceForm from GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "docassemble.EFSPIntegration>=1.5.1",
   "docassemble.MassAccess",
   "docassemble.MATCTheme",
+  "docassemble.MANoticeOfAppearanceForm @ git+https://github.com/SuffolkLITLab/docassemble-MANoticeOfAppearanceForm.git@main",
   "docassemble.ALToolbox"
 ]
 


### PR DESCRIPTION
Package is not on PyPI. Using git+ URL syntax to install directly from GitHub as suggested.